### PR TITLE
Better Ansible Role for MySQL Installation

### DIFF
--- a/ansible/group_vars/all.yml
+++ b/ansible/group_vars/all.yml
@@ -2,6 +2,3 @@
 # This is used for the nginx server configuration, but nginx should listen to all names
 server_hostname: vagrant.vm
 
-# To create a default password for database in Vagrant VM (do not use in production)
-mysql_root_password: p3LjY2LxznmK
-

--- a/ansible/playbooks/ejabberd_dev/roles/common/tasks/main.yml
+++ b/ansible/playbooks/ejabberd_dev/roles/common/tasks/main.yml
@@ -3,12 +3,12 @@
   # If we want to keep the distribution up-to-date: upgrade=yes
   apt: update_cache=yes cache_valid_time=3600
   tags: [update]
-  sudo: true
+  become: true
 
 # Tested with ubuntu
 - name: Install base packages for development
   apt: pkg={{ item }} state=installed
-  sudo: true
+  become: true
   tags: [packages]
   with_items:
     - curl

--- a/ansible/playbooks/ejabberd_dev/roles/erlang-src/tasks/main.yml
+++ b/ansible/playbooks/ejabberd_dev/roles/erlang-src/tasks/main.yml
@@ -17,5 +17,5 @@
   shell: cd {{ ansible_env.HOME }}/erlang/{{ erlangsrc }} && make
 
 - name: Make install
-  sudo: yes
+  become: true
   shell: cd {{ ansible_env.HOME }}/erlang/{{ erlangsrc }} && make install

--- a/ansible/playbooks/ejabberd_dev/roles/mysql/handlers/main.yml
+++ b/ansible/playbooks/ejabberd_dev/roles/mysql/handlers/main.yml
@@ -1,4 +1,4 @@
 ---
 - name: restart mysql
-  sudo: true
+  become: true
   service: name=mysql state=restarted

--- a/ansible/playbooks/ejabberd_dev/roles/mysql/handlers/main.yml
+++ b/ansible/playbooks/ejabberd_dev/roles/mysql/handlers/main.yml
@@ -1,20 +1,4 @@
 ---
-- name: mysql_secure_installation
-  action: template src=templates/mysql_secure_installation.j2 dest=/tmp/mysql_secure_installation owner=root group=root mode=0600
-  when: mysql_root_password is defined
-  notify:
-    - launch mysql_secure_installation
-    - delete mysql_secure_installation
-
-- name: launch mysql_secure_installation
-  when: mysql_root_password is defined
-  sudo: true
-  action: shell cat /tmp/mysql_secure_installation | mysql_secure_installation
-
-- name: delete mysql_secure_installation
-  when: mysql_root_password is defined
-  action: file dest=/tmp/mysql_secure_installation state=absent
-
 - name: restart mysql
   sudo: true
   service: name=mysql state=restarted

--- a/ansible/playbooks/ejabberd_dev/roles/mysql/tasks/main.yml
+++ b/ansible/playbooks/ejabberd_dev/roles/mysql/tasks/main.yml
@@ -1,17 +1,17 @@
 ---
 - name: Install mysql server package
-  sudo: true
+  become: true
   apt: pkg=mysql-server state=installed
   tags: [packages]
 
 # Used by Ansible
 - name: Install mysql python client
-  sudo: true
+  become: true
   apt: pkg=python-mysqldb state=installed
   tags: [packages]
 
 - name: Ensure mysql is started on boot
-  sudo: true
+  become: true
   service: name=mysql state=started enabled=true
 
 

--- a/ansible/playbooks/ejabberd_dev/roles/mysql/tasks/main.yml
+++ b/ansible/playbooks/ejabberd_dev/roles/mysql/tasks/main.yml
@@ -3,13 +3,6 @@
   sudo: true
   apt: pkg=mysql-server state=installed
   tags: [packages]
-  notify:
-    - mysql_secure_installation
-
-#- name: Create Mysql configuration file
-#  template: src=my.cnf dest=/etc/my.cnf
-#  notify:
-#  - restart mysql
 
 # Used by Ansible
 - name: Install mysql python client
@@ -21,6 +14,46 @@
   sudo: true
   service: name=mysql state=started enabled=true
 
-- mysql_user: name=ejabberd_test password=ejabberd_test priv=ejabberd_test.*:ALL state=present
 
-- mysql_db: name=ejabberd_test state=present
+# Emulate mysql_secure_installation
+- name: Set mysql root password
+  when: mysql_root_password is defined
+  mysql_user: login_user=root user=root password="{{ mysql_root_password }}"
+
+- name: Copy MySQL client config
+  when: mysql_root_password is defined
+  template: src=templates/dotmy.cnf dest=~/.my.cnf mode=0600
+
+- name: Delete anonymous mysql user for fqdn
+  mysql_user: name="" host="{{ ansible_fqdn }}" state=absent
+
+
+- name: Delete anonymous mysql user for localhost
+  mysql_user: name="" state=absent
+
+- name: Secure mysql root user for ipv6
+  when: mysql_root_password is defined
+  mysql_user: user="root" password="{{ mysql_root_password }}" host="::1"
+
+- name: Secure mysql root user for ipv4
+  when: mysql_root_password is defined
+  mysql_user: user="root" password="{{ mysql_root_password }}" host="127.0.0.1"
+
+- name: Secure mysql root user for localhost
+  when: mysql_root_password is defined
+  mysql_user: user="root" password="{{ mysql_root_password }}" host="localhost"
+
+- name: Secure mysql root user for fqdn
+  when: mysql_root_password is defined
+  mysql_user: user="root" password="{{ mysql_root_password }}" host="{{ ansible_fqdn }}"
+
+- name: Remove mysql default test database
+  mysql_db: db=test state=absent
+
+
+# Add ejabberd test user & db
+- name: Add ejabberd_test user
+  mysql_user: name=ejabberd_test password=ejabberd_test priv=ejabberd_test.*:ALL state=present
+
+- name: Add ejabberd_test database
+  mysql_db: name=ejabberd_test state=present

--- a/ansible/playbooks/ejabberd_dev/roles/mysql/templates/dotmy.cnf
+++ b/ansible/playbooks/ejabberd_dev/roles/mysql/templates/dotmy.cnf
@@ -1,0 +1,3 @@
+[client]
+user=root
+password={{ mysql_root_password }}

--- a/ansible/playbooks/ejabberd_dev/roles/mysql/vars/main.yml
+++ b/ansible/playbooks/ejabberd_dev/roles/mysql/vars/main.yml
@@ -1,0 +1,2 @@
+# To create a default password for database in Vagrant VM (do not use in production)
+mysql_root_password: p3LjY2LxznmK

--- a/ansible/playbooks/ejabberd_dev/roles/postgresql/tasks/main.yml
+++ b/ansible/playbooks/ejabberd_dev/roles/postgresql/tasks/main.yml
@@ -5,21 +5,21 @@
     - postgresql-client-9.1
     - python-psycopg2
   register: db_setup
-  sudo: true
+  become: true
   tags: postgres_packages
 
 - name: Ensure postgresql is started on boot
-  sudo: true
+  become: true
   service: name=postgresql state=started enabled=true
   
 # Create test database and user for ejabberd tests
 - name: Ensure ejabberd_test database is created
   postgresql_db: name=ejabberd_test template='template1'
-  sudo: yes
-  sudo_user: postgres
+  become: true
+  become_user: postgres
 
 - name: Ensure ejabberd_test user is created
   postgresql_user: db=ejabberd_test name=ejabberd_test password=ejabberd_test
-  sudo: yes
-  sudo_user: postgres
+  become: true
+  become_user: postgres
 

--- a/ansible/playbooks/ejabberd_dev/roles/redis/handlers/main.yml
+++ b/ansible/playbooks/ejabberd_dev/roles/redis/handlers/main.yml
@@ -1,4 +1,4 @@
 ---
 - name: restart redis
-  sudo: true
+  become: true
   service: name=redis-server state=restarted

--- a/ansible/playbooks/ejabberd_dev/roles/redis/tasks/main.yml
+++ b/ansible/playbooks/ejabberd_dev/roles/redis/tasks/main.yml
@@ -1,9 +1,9 @@
 ---
 - name: Install redis server package
-  sudo: true
+  become: true
   apt: pkg=redis-server state=installed
   tags: [packages]
 
 - name: Ensure redis is started on boot
-  sudo: true
+  become: true
   service: name=redis-server state=started enabled=true

--- a/ansible/playbooks/ejabberd_dev/roles/riak/tasks/main.yml
+++ b/ansible/playbooks/ejabberd_dev/roles/riak/tasks/main.yml
@@ -7,51 +7,51 @@
   get_url: url={{ riakurl }} dest={{ ansible_env.HOME }}/riak/{{ riakvsn }}.deb
 
 - name: Install riak package
-  sudo: true
+  become: true
   apt: deb={{ ansible_env.HOME }}/riak/{{ riakvsn }}.deb
 
 - name: Ensure soft nofile limits are adequate for Riak user
-  sudo: true
+  become: true
   lineinfile: dest=/etc/security/limits.conf backup=yes line="riak soft nofile 65536" insertbefore="# End of file"
 
 - name: Ensure hard nofile limits are adequate for Riak user
-  sudo: true
+  become: true
   lineinfile: dest=/etc/security/limits.conf backup=yes line="riak hard nofile 65536" insertbefore="# End of file"
 
 # Needed to tell Ubuntu Precise (12.04) to use limit settings:
 - name: Ensure PAM use security limits
-  sudo: true
+  become: true
   lineinfile: dest=/etc/pam.d/common-session backup=yes line="session required pam_limits.so" insertbefore="# end of pam-auth-update config"
   
 # == Configure Riak for ejabberd testing
 
 # Do not forget to update ejabberd_riak.beam (or manually symlink it) when testing
 - name: Copy ejabberd Riak beam
-  sudo: true
-  sudo_user: riak
+  become: true
+  become_user: riak
   copy: src=ejabberd_riak.beam dest=/etc/riak/ owner=riak group=riak mode=0644
 
 - name: Set Erlang parameters for Riak VM
-  sudo: true
-  sudo_user: riak
+  become: true
+  become_user: riak
   template: src=vm.args.j2 dest=/etc/riak/vm.args backup=yes owner=riak group=riak mode=0644
   
 - name: Ensure Riak is configured to use leveldb backend
-  sudo: true
-  sudo_user: riak
+  become: true
+  become_user: riak
   lineinfile: dest=/etc/riak/riak.conf backup=yes regexp="^storage_backend =" line="storage_backend = leveldb"
 
 - name: Ensure Riak can work for testing in a very small VM (Small ring)
-  sudo: true
-  sudo_user: riak
+  become: true
+  become_user: riak
   lineinfile: dest=/etc/riak/riak.conf regexp="^ring_size =" line="ring_size = 8" insertafter="## ring_size = 64"
   
 - name: Ensure Riak can work for testing in a very small VM (Disable anti-entropy)
-  sudo: true
-  sudo_user: riak
+  become: true
+  become_user: riak
   lineinfile: dest=/etc/riak/riak.conf regexp="^anti_entropy =" line="anti_entropy = passive"
 
 # == Ensure Riak is started on boot
 - name: Ensure Riak is started on boot
-  sudo: true
+  become: true
   service: name=riak state=started enabled=true


### PR DESCRIPTION
Hello!
The mysql ansible role was not working for me (root password did not get set properly and `mysql_user` tasks failed with an 'Access Denied' error).
I therefore reworked the mysql ansible role, replacing the call to `mysql_secure_installation` with (hopefully completely) equivalent ansible tasks, which seems to be best practice according to [here](https://stackoverflow.com/questions/25136498/ansible-answers-to-mysql-secure-installation).

Furthermore I replaced the deprecated 'sudo' privilege escalation method with 'become'.
[Ansible Docs](https://docs.ansible.com/ansible/become.html) state:

> As of 1.9 become supersedes the old sudo/su, while still being backwards compatible. 
